### PR TITLE
Modified JAX section to force JAX to use CPU after running on GPU

### DIFF
--- a/test.ipynb
+++ b/test.ipynb
@@ -44,7 +44,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "14.4 ms ± 131 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "30.7 ms ± 3.74 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -60,6 +60,7 @@
    "outputs": [],
    "source": [
     "device = torch.device(\"mps\")\n",
+    "# device = torch.device(\"cuda\") # specify CUDA to try this on an NVIDIA GPU\n",
     "x, y = create_torch_tensors(device)"
    ]
   },
@@ -72,7 +73,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.72 ms ± 19.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "9.8 ms ± 109 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -116,7 +117,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "15.3 ms ± 106 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "34.2 ms ± 906 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -136,7 +137,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.71 ms ± 25.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "9.74 ms ± 66.1 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -156,50 +157,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "os.environ[\"JAX_PLATFORMS\"] = \"cpu\""
+    "import jax\n",
+    "import jax.numpy as jnp"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Platform 'METAL' is experimental and not all JAX functionality may be correctly supported!\n",
-      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "W0000 00:00:1716385928.837884  732948 mps_client.cc:510] WARNING: JAX Apple GPU support is experimental and not all JAX functionality is correctly supported!\n",
-      "I0000 00:00:1716385928.845272  732948 service.cc:145] XLA service 0x12da04c10 initialized for platform METAL (this does not guarantee that XLA will be used). Devices:\n",
-      "I0000 00:00:1716385928.845282  732948 service.cc:153]   StreamExecutor device (0): Metal, <undefined>\n",
-      "I0000 00:00:1716385928.847533  732948 mps_client.cc:406] Using Simple allocator.\n",
-      "I0000 00:00:1716385928.847540  732948 mps_client.cc:384] XLA backend will use up to 103077429248 bytes on device 0 for SimpleAllocator.\n"
+      "Platform 'METAL' is experimental and not all JAX functionality may be correctly supported!\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Metal device set to: Apple M3 Max\n",
+      "Metal device set to: Apple M3 Pro\n",
       "\n",
-      "systemMemory: 128.00 GB\n",
-      "maxCacheSize: 48.00 GB\n",
+      "systemMemory: 36.00 GB\n",
+      "maxCacheSize: 13.50 GB\n",
       "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "W0000 00:00:1745919114.661742 12956740 mps_client.cc:510] WARNING: JAX Apple GPU support is experimental and not all JAX functionality is correctly supported!\n",
+      "I0000 00:00:1745919114.662170 12956740 service.cc:145] XLA service 0x40ffcb430 initialized for platform METAL (this does not guarantee that XLA will be used). Devices:\n",
+      "I0000 00:00:1745919114.662185 12956740 service.cc:153]   StreamExecutor device (0): Metal, <undefined>\n",
+      "I0000 00:00:1745919114.663527 12956740 mps_client.cc:406] Using Simple allocator.\n",
+      "I0000 00:00:1745919114.663538 12956740 mps_client.cc:384] XLA backend will use up to 25643024384 bytes on device 0 for SimpleAllocator.\n"
      ]
     }
    ],
    "source": [
-    "import jax\n",
-    "import jax.numpy as jnp\n",
-    "\n",
-    "\n",
+    "# using default GPU\n",
     "def create_jax_tensors():\n",
     "    x = jax.random.uniform(jax.random.PRNGKey(0), (10000, 10000), dtype=jnp.float32)\n",
     "    y = jax.random.uniform(jax.random.PRNGKey(1), (10000, 10000), dtype=jnp.float32)\n",
@@ -212,14 +215,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "3.72 ms ± 39.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "9.59 ms ± 15.1 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "x * y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Forcing JAX to use CPU for comparison\n",
+    "cpu_device = jax.devices(\"cpu\")[0]\n",
+    "\n",
+    "with jax.default_device(cpu_device):\n",
+    "    def create_jax_tensors():\n",
+    "        x = jax.random.uniform(jax.random.PRNGKey(0), (10000, 10000), dtype=jnp.float32)\n",
+    "        y = jax.random.uniform(jax.random.PRNGKey(1), (10000, 10000), dtype=jnp.float32)\n",
+    "\n",
+    "        return x, y\n",
+    "\n",
+    "\n",
+    "    x, y = create_jax_tensors()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "105 ms ± 532 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -238,7 +279,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "gpu-on",
    "language": "python",
    "name": "python3"
   },
@@ -252,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Modified JAX section to force JAX to use CPU after running the multiplication on the GPU. This allows for an easier comparison of performance.
(My device is an M3 pro, so performance is different from the M3 Max used in the original video, but the distinction between CPU and the M3 GPU is still very clear in the numbers.)